### PR TITLE
Mongoerror fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ Run with debugging output on:
 ```bash
   DEBUG='loopback-ds-changed-mixin' npm test
 ```
+
+Run the test with a mongodb datasource
+```bash
+  MONGODB_URL=mongodb://localhost/ds_changed_mixin npm test
+```

--- a/index.js
+++ b/index.js
@@ -113,6 +113,8 @@ function changed(Model, options) {
       }
     });
 
+    if (!fields.or.length) fields = {};
+
     // If there are no property conditions, do nothing.
     if (_.isEmpty(properties)) {
       process.nextTick(function() {

--- a/package.json
+++ b/package.json
@@ -17,17 +17,15 @@
     "debug": "2.x",
     "lodash": "latest"
   },
-  "peerDependencies": {
-    "loopback-datasource-juggler": ">=2.18.1"
-  },
   "devDependencies": {
     "bluebird": "2.9.24",
     "chai": "latest",
-    "loopback": "2.x",
-    "loopback-testing": "1.x",
-    "mocha": "2.x",
     "jscs": "1.13.x",
     "jshint": "latest",
+    "loopback": "2.x",
+    "loopback-connector-mongodb": "^1.11.1",
+    "loopback-datasource-juggler": "^2.30.1",
+    "loopback-testing": "1.x",
     "mocha": "latest",
     "mocha-sinon": "latest",
     "sinon": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-ds-changed-mixin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A mixin to enable loopback Model properties to be marked as changed.",
   "main": "index.js",
   "keywords": [

--- a/test.js
+++ b/test.js
@@ -53,6 +53,7 @@ describe('loopback datasource changed property', function() {
           callback: 'basicCallback',
           properties: {
             nickname: true,
+            nickname: true,
             age: true,
             status: true
           }
@@ -109,11 +110,13 @@ describe('loopback datasource changed property', function() {
 
       it('should run the callback after updating a watched property', function(done) {
         var self = this;
+        var expectedParams = {};
+        expectedParams[this.joe.id] = { age: 22 };
         this.joe.updateAttribute('age', 22)
         .then(function(res) {
           expect(res.age).to.equal(22);
           expect(self.spy).to.have.been.called;
-          expect(self.spy).to.have.been.calledWith([self.joe.id]);
+          expect(self.spy).to.have.been.calledWith(expectedParams);
           done();
         })
         .catch(done);
@@ -133,12 +136,14 @@ describe('loopback datasource changed property', function() {
 
       it('should execute the callback after updating watched properties', function(done) {
         var self = this;
+        var expectedParams = {};
+        expectedParams[this.joe.id] = { age: 22, nickname: "somename" };
         this.joe.updateAttributes({'age': 22, nickname: 'somename'})
         .then(function(res) {
           expect(res.age).to.equal(22);
           expect(res.nickname).to.equal('somename');
           expect(self.spy).to.have.been.called;
-          expect(self.spy).to.have.been.calledWith([self.joe.id]);
+          expect(self.spy).to.have.been.calledWith(expectedParams);
           done();
         })
         .catch(done);
@@ -159,12 +164,14 @@ describe('loopback datasource changed property', function() {
 
       it('should execute the callback after updating watched properties', function(done) {
         var self = this;
+        var expectedParams = {};
+        expectedParams[this.joe.id] = { age: 22, nickname: "somename" };
         this.joe.age = 22;
         this.joe.nickname = 'somename';
         this.joe.save()
         .then(function(res) {
           expect(self.spy).to.have.been.called;
-          expect(self.spy).to.have.been.calledWith([self.joe.id]);
+          expect(self.spy).to.have.been.calledWith(expectedParams);
           done();
         })
         .catch(done);
@@ -185,11 +192,13 @@ describe('loopback datasource changed property', function() {
 
       it('should execute the callback after updating watched properties', function(done) {
         var self = this;
+        var expectedParams = {};
+        expectedParams[this.joe.id] = { status: 'pending' };
         this.joe.status = 'pending';
         this.Person.upsert(this.joe)
         .then(function(res) {
           expect(self.spy).to.have.been.called;
-          expect(self.spy).to.have.been.calledWith([self.joe.id]);
+          expect(self.spy).to.have.been.calledWith(expectedParams);
           done();
         })
         .catch(done);
@@ -209,10 +218,13 @@ describe('loopback datasource changed property', function() {
 
       it('should execute the callback after updating watched properties on multiple models', function(done) {
         var self = this;
-        this.Person.updateAll(null, {status: 'pending'})
+        var expectedParams = {};
+        expectedParams[this.joe.id] = { status: 'pending' };
+        expectedParams[this.bilbo.id] = { status: 'pending' };
+        this.Person.updateAll(null, {status: 'pending', name: 'pending'})
         .then(function(res) {
           expect(self.spy).to.have.been.called;
-          expect(self.spy).to.have.been.calledWith([self.joe.id, self.bilbo.id]);
+          expect(self.spy).to.have.been.calledWith(expectedParams);
           done();
         })
         .catch(done);

--- a/test.js
+++ b/test.js
@@ -21,6 +21,22 @@ global.Promise = require('bluebird');
 // import our Changed mixin.
 require('./')(app);
 
+// Configure datasource
+var dbConnector = null;
+
+var MONGODB_URL = process.env.MONGODB_URL || null;
+if (MONGODB_URL) {
+  debug('Using mongodb datasource %s', MONGODB_URL);
+  var DataSource = require('loopback-datasource-juggler').DataSource;
+  dbConnector = new DataSource({
+    connector: require('loopback-connector-mongodb'),
+    url: MONGODB_URL
+  });
+} else {
+  debug('Using memory datasource');
+  dbConnector = loopback.memory();
+}
+
 describe('loopback datasource changed property', function() {
 
   beforeEach(function(done) {
@@ -57,7 +73,7 @@ describe('loopback datasource changed property', function() {
     // Set up a spy so we can check wether our callback has been called.
     this.spy = sinon.spy(Person, 'basicCallback');
 
-    Person.attachTo(loopback.memory());
+    Person.attachTo(dbConnector);
     app.model(Person);
 
     app.use(loopback.rest());


### PR DESCRIPTION
It seems that this patch fixes the MongoDB error:

`MongoError: Can't canonicalize query: BadValue $and/$or/$nor must be a nonempty array`
