### PR TITLE
Provide a 2nd argument with old values

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ property will be executed with a ChangeSet as a parameter.
 ```javascript
 
 // The ChangeSet object passed here has several helper methods    
-function changeName(changeSet) {
+function changeName(changeSet, oldChangeSet) {
 
     // Return an array of all the ID's in this change set
     changeSet.getIdList();
@@ -92,6 +92,10 @@ function changeName(changeSet) {
     // The raw data is available as well
     changeSet.ids;
     changeSet.values;
+    
+    // oldChangeSet is a similar object providing previous values
+    // Return the previous value (before current update) for a given ID
+    oldChangeSet.getId(id);
 
 }
 

--- a/lib/changed.js
+++ b/lib/changed.js
@@ -173,11 +173,14 @@ module.exports = function(Model, options) {
   Model.observe('after save', function(ctx, next) {
 
     // Convert the changeItems to Properties
-    if (ctx.hookState.changedItems && !_.isEmpty(ctx.hookState.changedItems)) {
+    debug('after save changedItems %o', ctx.hookState.changedItems);
+    if (ctx.hookState.changedItems && !_.isEmpty(ctx.hookState.changedItems.changedProperties)) {
 
-      var properties = convertItemsToProperties(ctx.hookState.changedItems);
+      var properties = convertItemsToProperties(ctx.hookState.changedItems.changedProperties);
+      var oldProperties = convertItemsToProperties(ctx.hookState.changedItems.oldProperties);
 
       debug('after save changedProperties %o', properties);
+      debug('after save oldProperties %o', oldProperties);
 
       async.forEachOf(properties, function(changeset, property, cb) {
         var callback = options.properties[property];
@@ -188,8 +191,9 @@ module.exports = function(Model, options) {
         if (typeof Model[callback] !== 'function') {
           return cb(new Error(util.format('Function %s not found on Model', callback)));
         }
+        var oldChangeset = oldProperties[property];
         debug('after save: invoke %s with %o', callback, changeset);
-        Model[callback](changeset).then(function() {
+        Model[callback](changeset, oldChangeset).then(function() {
           cb();
         }).catch(cb);
       }, function(err) {
@@ -285,6 +289,7 @@ module.exports = function(Model, options) {
         debug('itemsWithChangedProperties: filter results %o', results);
 
         var changedProperties = {};
+        var oldProperties = {};
 
         results.map(function(oldVals) {
 
@@ -294,6 +299,7 @@ module.exports = function(Model, options) {
           //changedProperties[oldVals.id] = {};
 
           var changed = {};
+          var changedOldVals = {};
 
           properties.map(function(property) {
 
@@ -307,11 +313,13 @@ module.exports = function(Model, options) {
 
               if (!oldVals[property]) {
                 changed[property] = newVal;
+                changedOldVals[property] = undefined;
                 debug('itemsWithChangedProperties:   - no oldVal %s : %s : ', property, newVal);
               } else if (!_.isEqual(oldVals[property], newVal)) {
                 var oldVal = oldVals[property];
                 debug('itemsWithChangedProperties:   - oldVal %s : %s : ', property, oldVal);
                 changed[property] = newVal;
+                changedOldVals[property] = oldVal;
               }
 
             }
@@ -319,10 +327,14 @@ module.exports = function(Model, options) {
 
           debug('itemsWithChangedProperties: changed %o', changed);
           changedProperties[oldVals.id] = changed;
+          oldProperties[oldVals.id] = changedOldVals;
         });
 
-        debug('itemsWithChangedProperties: changedProperties %o', changedProperties);
-        cb(null, changedProperties);
+        debug('itemsWithChangedProperties: changedProperties - oldProperties %o -%o', changedProperties, oldProperties);
+        cb(null, {
+          changedProperties: changedProperties,
+          oldProperties: oldProperties
+        });
       }).catch(cb);
 
     return cb.promise;
@@ -349,7 +361,9 @@ module.exports = function(Model, options) {
 
     Model.findById(this.getId())
       .then(function(instance) {
-        var changedProperties = Model.getChangedProperties(instance, data, properties);
+        var changedProperties =
+            Model
+            .getChangedProperties(instance, data, properties);
         debug('itemHasChangedProperties: found supposedly changed items: %o', changedProperties);
         cb(null, changedProperties);
       }).catch(cb);
@@ -389,7 +403,10 @@ module.exports = function(Model, options) {
 
     var itemId = oldVals[Model.getIdName()];
     var changedProperties = {};
+    var oldProperties = {};
+
     changedProperties[itemId] = {};
+    oldProperties[itemId] = {};
 
     _.forEach(properties, function(key) {
       debug('getChangedProperties: - checking property %s ', key);
@@ -402,12 +419,17 @@ module.exports = function(Model, options) {
           debug('getChangedProperties:   - changed or new value: %s itemId: %s', newVal, itemId);
 
           changedProperties[itemId][key] = newVal;
+          oldProperties[itemId][key] = oldVals[key];
         }
       }
     });
     if (!_.isEmpty(changedProperties[itemId])) {
       debug('getChangedProperties: Properties were changed %o', changedProperties);
-      return changedProperties;
+      //return changedProperties;
+      return {
+        changedProperties: changedProperties,
+        oldProperties: oldProperties
+      };
     }
     return false;
   };

--- a/test/fixtures/simple-app/common/models/person.js
+++ b/test/fixtures/simple-app/common/models/person.js
@@ -3,9 +3,9 @@ var debug = require('debug')('loopback-ds-changed-mixin');
 
 module.exports = function(Person) {
   // Define a function that should be called when a change is detected.
-  Person.changeName = function(args, cb) {
+  Person.changeName = function(changeset, oldChangeset, cb) {
     cb = cb || utils.createPromiseCallback();
-    debug('this.changeName() called with %o', args);
+    debug('this.changeName() called with %o %o', changeset, oldChangeset);
     process.nextTick(function() {
       cb(null);
     });
@@ -13,9 +13,9 @@ module.exports = function(Person) {
   };
 
   // Define a function that should be called when a change is detected.
-  Person.changeStatus = function(args, cb) {
+  Person.changeStatus = function(changeset, oldChangeset, cb) {
     cb = cb || utils.createPromiseCallback();
-    debug('this.changeStatus() called with %o', args);
+    debug('this.changeStatus() called with %o %o', changeset, oldChangeset);
     process.nextTick(function() {
       cb(null);
     });
@@ -23,9 +23,9 @@ module.exports = function(Person) {
   };
 
   // Define a function that should be called when a change is detected.
-  Person.changeAge = function(args, cb) {
+  Person.changeAge = function(changeset, oldChangeset, cb) {
     cb = cb || utils.createPromiseCallback();
-    debug('this.changeAge() called with %o', args);
+    debug('this.changeAge() called with %o %o', changeset, oldChangeset);
     process.nextTick(function() {
       cb(null);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -268,6 +268,14 @@ describe('loopback datasource changed property', function() {
           expect(self.spyAge).not.to.have.been.called;
           expect(self.spyName).not.to.have.been.called;
           expect(self.spyStatus).to.have.been.called;
+
+          var changeset = self.spyStatus.args[0][0];
+          var oldChangeset = self.spyStatus.args[0][1];
+          var oldVal = oldChangeset.getId(self.joe.id);
+          var newVal = changeset.getId(self.joe.id);
+          expect(oldVal).to.equal('active');
+          expect(newVal).to.equal('test');
+
           done();
         })
         .catch(done);
@@ -333,6 +341,7 @@ describe('loopback datasource changed property', function() {
             expect(self.spyAge).not.to.have.been.called;
             expect(self.spyName).not.to.have.been.called;
             expect(self.spyStatus).to.have.been.called;
+
             done();
           })
         .catch(done);
@@ -345,6 +354,18 @@ describe('loopback datasource changed property', function() {
             expect(self.spyAge).not.to.have.been.called;
             expect(self.spyStatus).to.have.been.called;
             expect(self.spyName).not.to.have.been.called;
+
+            var changeset = self.spyStatus.args[0][0];
+            var oldChangeset = self.spyStatus.args[0][1];
+
+            expect(oldChangeset.getId(self.joe.id)).to.equal('active');
+            expect(changeset.getId(self.joe.id)).to.equal('pending');
+            expect(oldChangeset.getId(self.bilbo.id)).to.equal('active');
+            expect(changeset.getId(self.bilbo.id)).to.equal('pending');
+            // Tina should not have been updated as her status was already 'pending'
+            expect(oldChangeset.getId(self.tina.id)).to.equal(undefined);
+            expect(changeset.getId(self.tina.id)).to.equal(undefined);
+
             done();
           })
           .catch(done);


### PR DESCRIPTION
It would be quite useful to have the old (previous) values in addition to the new ones.

For example, I'm using it in an after save hook to create a history of the values for a certain property.

This change provides a 2nd argument in the change function containing another changeset object with the previous values, so that a change function might now look like this:

```
function changeName(changeSet, oldchangeSet) {
    //
}
```