### PR TITLE
used on boolean field change callback not triggered when update to false

### DIFF
--- a/lib/changed.js
+++ b/lib/changed.js
@@ -394,7 +394,7 @@ module.exports = function(Model, options) {
     _.forEach(properties, function(key) {
       debug('getChangedProperties: - checking property %s ', key);
 
-      if (newVals[key]) {
+      if (newVals[key] !== undefined) {
         var newVal = newVals[key];
         debug('getChangedProperties:   - new value %s ', newVal);
 

--- a/lib/changed.js
+++ b/lib/changed.js
@@ -398,7 +398,7 @@ module.exports = function(Model, options) {
         var newVal = newVals[key];
         debug('getChangedProperties:   - new value %s ', newVal);
 
-        if (!oldVals[key] || !_.isEqual(oldVals[key], newVal)) {
+        if (oldVals[key] === undefined || !_.isEqual(oldVals[key], newVal)) {
           debug('getChangedProperties:   - changed or new value: %s itemId: %s', newVal, itemId);
 
           changedProperties[itemId][key] = newVal;

--- a/test/fixtures/simple-app/common/models/person.js
+++ b/test/fixtures/simple-app/common/models/person.js
@@ -21,6 +21,14 @@ module.exports = function(Person) {
     });
     return cb.promise;
   };
+  Person.changeFlag = function(args, cb) {
+    cb = cb || utils.createPromiseCallback();
+    debug('this.changeFlag() called with %o', args);
+    process.nextTick(function() {
+      cb(null);
+    });
+    return cb.promise;
+  };
 
   // Define a function that should be called when a change is detected.
   Person.changeAge = function(args, cb) {

--- a/test/fixtures/simple-app/common/models/person.json
+++ b/test/fixtures/simple-app/common/models/person.json
@@ -9,7 +9,8 @@
     "name": "String",
     "nickname": "String",
     "age": "Number",
-    "status": "String"
+    "status": "String",
+    "flag": "boolean"
   },
   "validations": [],
   "relations": {},
@@ -20,7 +21,8 @@
         "name": "changeName",
         "nickname": "changeName",
         "age": "changeAge",
-        "status": "changeStatus"
+        "status": "changeStatus",
+        "flag": "changeFlag"
       }
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -129,6 +129,19 @@ describe('loopback datasource changed property', function() {
                 })
                 .catch(done);
       });
+      it('should run the callback after updating a watched property', function(done) {
+        var self = this;
+        this.tina.updateAttribute('flag', true)
+                .then(function(res) {
+                  expect(res.flag).to.equal(true);
+                  expect(self.spyAge).not.to.have.been.called;
+                  expect(self.spyStatus).not.to.have.been.called;
+                  expect(self.spyName).not.to.have.been.called;
+                  expect(self.spyFlag).to.have.been.called;
+                  done();
+                })
+                .catch(done);
+      });
     });
 
     describe('Model.updateAttributes', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -38,24 +38,26 @@ describe('loopback datasource changed property', function() {
     this.spyAge = this.sinon.spy(app.models.Person, 'changeAge');
     this.spyStatus = this.sinon.spy(app.models.Person, 'changeStatus');
     this.spyName = this.sinon.spy(app.models.Person, 'changeName');
+    this.spyFlag = this.sinon.spy(app.models.Person, 'changeFlag');
   });
 
   lt.beforeEach.withApp(app);
 
   describe('when called internally', function() {
     lt.beforeEach.givenModel('Person',
-      {title: 'Mr', name:'Joe Blogs', nickname: 'joe', age: 21, status: 'active'}, 'joe');
+      {title: 'Mr', name:'Joe Blogs', nickname: 'joe', age: 21, status: 'active', flag: true}, 'joe');
     lt.beforeEach.givenModel('Person',
-      {title: 'Mr', name:'Bilbo Baggins', nickname: 'bilbo', age: 99, status: 'active'}, 'bilbo');
+      {title: 'Mr', name:'Bilbo Baggins', nickname: 'bilbo', age: 99, status: 'active', flag: true}, 'bilbo');
     lt.beforeEach.givenModel('Person',
-      {title: 'Miss', name:'Tina Turner', nickname: 'tina', age: 80, status: 'pending'}, 'tina');
+      {title: 'Miss', name:'Tina Turner', nickname: 'tina', age: 80, status: 'pending', flag: false}, 'tina');
 
     describe('Model.create', function() {
       it('should not run callback when creating new instances.', function(done) {
         var self = this;
-      expect(self.spyAge).not.to.have.been.called;
+        expect(self.spyAge).not.to.have.been.called;
         expect(self.spyStatus).not.to.have.been.called;
         expect(self.spyName).not.to.have.been.called;
+        expect(self.spyFlag).not.to.have.been.called;
         done();
       });
     });
@@ -68,6 +70,7 @@ describe('loopback datasource changed property', function() {
           expect(self.spyAge).not.to.have.been.called;
           expect(self.spyStatus).not.to.have.been.called;
           expect(self.spyName).not.to.have.been.called;
+          expect(self.spyFlag).not.to.have.been.called;
           done();
         })
         .catch(done);
@@ -80,6 +83,7 @@ describe('loopback datasource changed property', function() {
           expect(self.spyAge).not.to.have.been.called;
           expect(self.spyStatus).not.to.have.been.called;
           expect(self.spyName).not.to.have.been.called;
+          expect(self.spyFlag).not.to.have.been.called;
           done();
         })
         .catch(done);
@@ -92,6 +96,7 @@ describe('loopback datasource changed property', function() {
           expect(self.spyAge).not.to.have.been.called;
           expect(self.spyStatus).not.to.have.been.called;
           expect(self.spyName).not.to.have.been.called;
+          expect(self.spyFlag).not.to.have.been.called;
           done();
         })
         .catch(done);
@@ -105,9 +110,24 @@ describe('loopback datasource changed property', function() {
           expect(self.spyAge).to.have.been.called;
           expect(self.spyStatus).not.to.have.been.called;
           expect(self.spyName).not.to.have.been.called;
+          expect(self.spyFlag).not.to.have.been.called;
           done();
         })
         .catch(done);
+      });
+
+      it('should run the callback after updating a watched property', function(done) {
+        var self = this;
+        this.joe.updateAttribute('flag', false)
+                .then(function(res) {
+                  expect(res.flag).to.equal(false);
+                  expect(self.spyAge).not.to.have.been.called;
+                  expect(self.spyStatus).not.to.have.been.called;
+                  expect(self.spyName).not.to.have.been.called;
+                  expect(self.spyFlag).to.have.been.called;
+                  done();
+                })
+                .catch(done);
       });
     });
 
@@ -119,6 +139,7 @@ describe('loopback datasource changed property', function() {
           expect(self.spyAge).not.to.have.been.called;
           expect(self.spyStatus).not.to.have.been.called;
           expect(self.spyName).not.to.have.been.called;
+          expect(self.spyFlag).not.to.have.been.called;
           done();
         })
         .catch(done);


### PR DESCRIPTION
if set up the mixins on a boolean property only the change from false to true is detected (and callback is called) but transaction from true to false was not detected, my pr solve the issue